### PR TITLE
Tags: Remove the usage of the deprecated getTags method and use getSe…

### DIFF
--- a/src/AsuraScans/AsuraScans.ts
+++ b/src/AsuraScans/AsuraScans.ts
@@ -81,6 +81,11 @@ export class AsuraScans extends MangaStream {
     override homescreen_TopMonthly_enabled = true
     override homescreen_TopWeekly_enabled = true
 
+    override tags_selector_box: string = "ul.genrez"
+    override tags_selector_label: string = "label"
+    override tags_SubdirectoryPathName: string = "/manga/"
+    override tags_use_label_as_id: boolean = true
+
     /*
     ----TAG SELECTORS
     PRESET 1 (default): Genres are on homepage ex. https://mangagenki.com/

--- a/src/MangaStream.ts
+++ b/src/MangaStream.ts
@@ -51,7 +51,7 @@ interface StatusTypes {
 
 
 // Set the version for the base, changing this version will change the versions of all sources
-const BASE_VERSION = '2.1.5'
+const BASE_VERSION = '2.1.6'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }
@@ -176,6 +176,11 @@ export abstract class MangaStream extends Source {
 
     //----TAGS SELECTORS----
     /**
+     * Use the Tag Label as Id (Some Sites dont have an Id for their Tags)
+     * Default = false
+     */
+    tags_use_label_as_id = false
+    /**
      * The selector to select the subdirectory for the genre page
      * Eg. https://mangadark.com/genres/ needs this selector to be set to "/genres/"
      * Default = ""
@@ -292,7 +297,7 @@ export abstract class MangaStream extends Source {
         return this.parser.parseChapterDetails($, mangaId, chapterId)
     }
 
-    override async getTags(): Promise<TagSection[]> {
+    override async getSearchTags(): Promise<TagSection[]> {
         const request = createRequestObject({
             url: `${this.baseUrl}/`,
             method: 'GET',

--- a/src/MangaStreamParser.ts
+++ b/src/MangaStreamParser.ts
@@ -142,7 +142,7 @@ export class MangaStreamParser {
         const arrayTags: Tag[] = []
         for (const tag of $(source.tags_selector_item, source.tags_selector_box).toArray()) {
             const label = source.tags_selector_label ? $(source.tags_selector_label, tag).text().trim() : $(tag).text().trim()
-            const id = encodeURI($('a', tag).attr('href')?.replace(`${source.baseUrl}/genres/`, '').replace(/\//g, '') ?? '')
+            const id = source.tags_use_label_as_id ? label : encodeURI($('a', tag).attr('href')?.replace(`${source.baseUrl}/genres/`, '').replace(/\//g, '') ?? '')
             if (!id || !label) continue
             arrayTags.push({ id: id, label: label })
         }


### PR DESCRIPTION
…archTags instead.. also implemented Tags for AsuraScans

* Introduced a new variable "tags_use_label_as_id" for sites which dont expose the tags and making the id parsing possible
* Replaced getTags with getSearchTags (also fixes that tags will now work for 0.8)